### PR TITLE
Added the reg_max parameter as an option for the instantion of a YOLO…

### DIFF
--- a/ultralytics/cfg/models/v8/yolov8-cls.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-cls.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 1000  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n-cls.yaml' will call yolov8-cls.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]

--- a/ultralytics/cfg/models/v8/yolov8-p2.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-p2.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call yolov8.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]

--- a/ultralytics/cfg/models/v8/yolov8-p6.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-p6.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n-p6.yaml' will call yolov8-p6.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]

--- a/ultralytics/cfg/models/v8/yolov8-pose-p6.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-pose-p6.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 1  # number of classes
+reg_max: 16 # DFL channels
 kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
 scales: # model compound scaling constants, i.e. 'model=yolov8n-p6.yaml' will call yolov8-p6.yaml with scale 'n'
   # [depth, width, max_channels]

--- a/ultralytics/cfg/models/v8/yolov8-pose.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-pose.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 1  # number of classes
+reg_max: 16 # DFL channels
 kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
 scales: # model compound scaling constants, i.e. 'model=yolov8n-pose.yaml' will call yolov8-pose.yaml with scale 'n'
   # [depth, width, max_channels]

--- a/ultralytics/cfg/models/v8/yolov8-rtdetr.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-rtdetr.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call yolov8.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]  # YOLOv8n summary: 225 layers,  3157200 parameters,  3157184 gradients,   8.9 GFLOPs

--- a/ultralytics/cfg/models/v8/yolov8-seg-p6.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-seg-p6.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n-seg-p6.yaml' will call yolov8-seg-p6.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]

--- a/ultralytics/cfg/models/v8/yolov8-seg.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-seg.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n-seg.yaml' will call yolov8-seg.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]

--- a/ultralytics/cfg/models/v8/yolov8.yaml
+++ b/ultralytics/cfg/models/v8/yolov8.yaml
@@ -3,6 +3,7 @@
 
 # Parameters
 nc: 80  # number of classes
+reg_max: 16 # DFL channels
 scales: # model compound scaling constants, i.e. 'model=yolov8n.yaml' will call yolov8.yaml with scale 'n'
   # [depth, width, max_channels]
   n: [0.33, 0.25, 1024]  # YOLOv8n summary: 225 layers,  3157200 parameters,  3157184 gradients,   8.9 GFLOPs

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -27,11 +27,11 @@ class Detect(nn.Module):
     anchors = torch.empty(0)  # init
     strides = torch.empty(0)  # init
 
-    def __init__(self, nc=80, ch=()):  # detection layer
+    def __init__(self, nc=80, ch=(), reg_max=16):  # detection layer
         super().__init__()
         self.nc = nc  # number of classes
         self.nl = len(ch)  # number of detection layers
-        self.reg_max = 16  # DFL channels (ch[0] // 16 to scale 4/8/12/16/20 for n/s/m/l/x)
+        self.reg_max = reg_max  # DFL channels (ch[0] // 16 to scale 4/8/12/16/20 for n/s/m/l/x)
         self.no = nc + self.reg_max * 4  # number of outputs per anchor
         self.stride = torch.zeros(self.nl)  # strides computed during build
         c2, c3 = max((16, ch[0] // 4, self.reg_max * 4)), max(ch[0], min(self.nc, 100))  # channels
@@ -84,9 +84,9 @@ class Detect(nn.Module):
 class Segment(Detect):
     """YOLOv8 Segment head for segmentation models."""
 
-    def __init__(self, nc=80, nm=32, npr=256, ch=()):
+    def __init__(self, nc=80, nm=32, npr=256, ch=(), reg_max=16):
         """Initialize the YOLO model attributes such as the number of masks, prototypes, and the convolution layers."""
-        super().__init__(nc, ch)
+        super().__init__(nc, ch, reg_max)
         self.nm = nm  # number of masks
         self.npr = npr  # number of protos
         self.proto = Proto(ch[0], self.npr, self.nm)  # protos

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -616,7 +616,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
 
     # Args
     max_channels = float('inf')
-    nc, act, scales = (d.get(x) for x in ('nc', 'activation', 'scales'))
+    nc, act, scales, reg_max = (d.get(x) for x in ('nc', 'activation', 'scales', 'reg_max'))
     depth, width, kpt_shape = (d.get(x, 1.0) for x in ('depth_multiple', 'width_multiple', 'kpt_shape'))
     if scales:
         scale = d.get('scale')
@@ -669,6 +669,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
             args.append([ch[x] for x in f])
             if m is Segment:
                 args[2] = make_divisible(min(args[2], max_channels) * width, 8)
+                args.append(d['reg_max'])
         elif m is RTDETRDecoder:  # special case, channels arg must be passed in index 1
             args.insert(1, [ch[x] for x in f])
         else:


### PR DESCRIPTION
I added the reg_max parameter as an option for the instantiation of a YOLOv8 model. By default this was hardcoded in the Detect head with the value 16. I also added this default value (as previously hardcoded) to all the YOLOv8 config files.

As I understand from issue [#3072](https://github.com/ultralytics/ultralytics/issues/3072)

> @xkangKK hello! The Reg_Max parameter is used to define the maximum range of anchor parameters. Anchor parameters are predefined bounding box sizes and aspect ratios that are used during training to detect objects of different sizes and shapes in your images.
> 
> The Reg_Max value is related to the scale of the anchors, meaning that a larger value of Reg_Max allows for larger anchor scales, which is useful for detecting larger objects. On the other hand, a smaller Reg_Max value allows for smaller anchor scales and can help with detecting smaller objects.
> 
> The optimal value for Reg_Max depends on the size and scale of the objects you want to detect in your images. Generally, larger image resolutions will require larger anchor scales, which may require increasing the Reg_Max value. You may need to experiment with different values of Reg_Max to determine the optimal value for your specific use case.
> 
> I hope this helps! Let me know if you have any further questions.


The reg_max parameter is also quoted in issue #3362, #2186 and #2843 

<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 911ecf5</samp>

### Summary
:sparkles::gear::memo:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or enhancement to the YOLOv8 models, namely the DFL module and its parameter `reg_max`.
2.  :gear: This emoji represents the modification of the configuration and parsing logic for the YOLOv8 models, which now need to handle the new parameter `reg_max`.
3.  :memo: This emoji represents the update of the documentation and comments for the YOLOv8 models, which now need to explain the new parameter `reg_max` and its effects.
-->
This pull request introduces a new parameter `reg_max` that controls the number of channels for the dense feature learning (DFL) module of the YOLOv8 models. The DFL module is a novel component that enhances the feature representation and localization ability of the network. The parameter is configurable from the YAML files and affects the output dimensions of the detection, segment, panoptic, and pose heads.

> _We unleash the power of the DFL_
> _We set the `reg_max` to control the hell_
> _We create the variants of the YOLOv8_
> _We dominate the vision with the ultimate fate_

### Walkthrough
*  Add `reg_max` parameter to YAML configuration files for YOLOv8 models and variants, which controls the number of channels for the dense feature learning module ([link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-d1e2a4a38c14f88accf354b22c24facc0623c61cbfedca4ef82fc4b195002748R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-620ffb05bd9d6e77d118a5655cde8c140309e3a2990181f0c409707c03a23a6fR6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-dddbcc4bf830494d2d661e0da7fb43adead7cb1e18954a358be882a11317a1b8R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-6186355278d1de2c064900a586397ed149fec3d47169615ff81bb460857f68b1R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-d80429b0998e95a034f0491284b141eec595d2a2e71382c5a23da5baa565fc15R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-e5138eb4e4be8a4bc5789738ba163ad92ab445f45bc4841f5f62e1352f7585b1R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-39450e630db6d5e0ddb73b8af588aa14bf396ef7ebfaa0243ab0a850b5a22fdbR6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-6139c57547bb92969e04e693ff178d204f380579fc4166c0f2ea452a4ad37e29R6), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-f882b2d409c1b8b36f4e168cd062ba38aa1d3ea8e3e061e025b28df6c793157fR6))
*  Modify `Detect` and `Segment` classes in `head.py` to accept `reg_max` argument and use it to compute the number of outputs per anchor ([link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L30-R34), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-06038a7c9e9c565760881118b974c2f2fe7aee7c78bb6c142d1498d0d9614639L87-R89))
*  Modify `parse_model` function in `tasks.py` to obtain `reg_max` value from YAML files and pass it to `Detect` and `Segment` classes when building the models ([link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4L619-R619), [link](https://github.com/ultralytics/ultralytics/pull/4693/files?diff=unified&w=0#diff-e2650ac65b6525f6d9c0594a226066d396afbcba637c054d29abe04e62f410c4R672))

