### PR TITLE
Set device for Predictor to other device than CUDA:0 bug

### DIFF
--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -28,6 +28,7 @@ Usage - formats:
                               yolov8n_paddle_model       # PaddlePaddle
 """
 import platform
+import re
 from pathlib import Path
 
 import cv2
@@ -300,10 +301,20 @@ class BasePredictor:
 
         self.run_callbacks('on_predict_end')
 
+    def is_plausible_device(self, device):
+        # Define a regular expression pattern to match 'cuda:x' format where x is an integer.
+        pattern = r'^cuda:\d+$'
+
+        # Use the re.match() function to check if the input_string matches the pattern.
+        match = re.match(pattern, device)
+
+        # If there is a match, return True. Otherwise, return False.
+        return bool(match)
+
     def setup_model(self, model, verbose=True):
         """Initialize YOLO model with given parameters and set it to evaluation mode."""
         self.model = AutoBackend(model or self.args.model,
-                                 device=select_device(self.args.device, verbose=verbose),
+                                 device=self.args.device if self.is_plausible_device(self.args.device) else select_device(self.args.device, verbose=verbose),
                                  dnn=self.args.dnn,
                                  data=self.args.data,
                                  fp16=self.args.half,


### PR DESCRIPTION
When creating a predictor model using `setup_model()` the device can be given with `self.args.device`. However as it turns out after a long and tiring search Torch's function `select_device()` always returns `cuda:0` even if the argument passed on is `cuda:any-other-possible-int-than-0`.

I fixed this in a shallow way by implementing a function that checks if the argument that is passed follows the format `cuda:x` with x being an integer. If so we simply set the device to the given argument, else we still run Torch's more extensive algorithm.

Assumption: the user correctly passes an existing cuda device, else the resulting error will so so.